### PR TITLE
docs and code say 'qobj' but example used 'obj'

### DIFF
--- a/README
+++ b/README
@@ -29,7 +29,7 @@ SYNOPSIS
   MOCKING OBJECTS
         use Mock::Quick;
 
-        my $obj = obj(
+        my $obj = qobj(
             foo => 'bar',            # define attribute
             do_it => qmeth { ... },  # define method
             ...

--- a/lib/Mock/Quick.pm
+++ b/lib/Mock/Quick.pm
@@ -54,7 +54,7 @@ object falls out of scope the original class is restored.
 
     use Mock::Quick;
 
-    my $obj = obj(
+    my $obj = qobj(
         foo => 'bar',            # define attribute
         do_it => qmeth { ... },  # define method
         ...


### PR DESCRIPTION
simple fix.
