### PR TITLE
Fixed name of distribution in DESCRIPTION

### DIFF
--- a/README
+++ b/README
@@ -12,14 +12,14 @@ DESCRIPTION
     particularly a problem if you only want to override a class on a lexical
     level.
 
-    Mock-Object provides a declarative mocking interface that results in a
+    Mock-Quick provides a declarative mocking interface that results in a
     very concise, but clear syntax. There are separate facilities for
     mocking object instances, and classes. You can quickly create an
     instance of an object with custom attributes and methods. You can also
     quickly create an anonymous class, optionally inheriting from another,
     with whatever methods you desire.
 
-    Mock-Object also provides a tool that provides an OO interface to
+    Mock-Quick also provides a tool that provides an OO interface to
     overriding methods in existing classes. This tool also allows for the
     restoration of the original class methods. Best of all this is a
     localized tool, when your control object falls out of scope the original

--- a/lib/Mock/Quick.pm
+++ b/lib/Mock/Quick.pm
@@ -103,13 +103,13 @@ Some Mocking libraries expect you to mock a specific class, and will unload it
 then redefine it. This is particularly a problem if you only want to override
 a class on a lexical level.
 
-Mock-Object provides a declarative mocking interface that results in a very
+Mock-Quick provides a declarative mocking interface that results in a very
 concise, but clear syntax. There are separate facilities for mocking object
 instances, and classes. You can quickly create an instance of an object with
 custom attributes and methods. You can also quickly create an anonymous class,
 optionally inheriting from another, with whatever methods you desire.
 
-Mock-Object also provides a tool that provides an OO interface to overriding
+Mock-Quick also provides a tool that provides an OO interface to overriding
 methods in existing classes. This tool also allows for the restoration of the
 original class methods. Best of all this is a localized tool, when your control
 object falls out of scope the original class is restored.


### PR DESCRIPTION
Mock-Object in the DESCRIPTION was probably a remnant of a previous distribution, but seems out of place here.
